### PR TITLE
Stop the open window from moving around after a rebuilt.

### DIFF
--- a/src/doxygen.ts
+++ b/src/doxygen.ts
@@ -109,7 +109,9 @@ export class Doxygen {
             this.viewIndex();
         } else {
             this.reloadPage();
-            this.active_panel.reveal();
+            if(this.active_panel.visible !== true) {
+                this.active_panel.reveal();
+            }
         }
     }
 


### PR DESCRIPTION
At least in my current vs code installation the tab with the preview was switching the tab position after regenerating the doxyfile. 