### PR TITLE
Add option to disable auto view after generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,15 @@ The default is
 ],
 ```
 
+#### Option `doxygen_runner.view_after_generate`
+
+Specifies whether the `View Doxygen documentation` command should be executed automatically after `Generate Doxygen documentation`.
+
 ## Usage: Commands
 
 There are the following commands:
 
-* `Generate Doxygen documentation`: This (re-)generates the Doxygen output when run. Afterwards it will automatically run `View Doxygen documentation`.
+* `Generate Doxygen documentation`: This (re-)generates the Doxygen output when run. Afterwards it will automatically run `View Doxygen documentation` if `doxygen_runner.view_after_generate` is `true`.
 * `View Doxygen documentation`: This will show a preview of the generated documentation in a new panel.
 
 ## Usage: Crawling mode

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
             "type": "string",
             "default": "",
             "description": "If set, disable crawling the workspace for Doxygen configuration and use this path. \n You can use ${workspaceFolder} here. The variable will be replaced with all folders added to this workspace. \n (In case there are multiple matches, an error will be shown.)"
+          },
+          "doxygen_runner.view_after_generate": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether the Generate Doxygen documentation command will automatically run View Doxygen documentation"
           }
         }
       }

--- a/src/doxygen.ts
+++ b/src/doxygen.ts
@@ -43,7 +43,10 @@ export class Doxygen {
                 this.diagnostics.clear();
                 problem_matcher.analyze(stderr.replace(/\r/gi, '').split('\n'), this.doxyfile, this.diagnostics);
                 // display the generated documentation
-                vscode.commands.executeCommand('extension.doxygen-runner.view_doxygen', this.basedir);
+                let config = vscode.workspace.getConfiguration('doxygen_runner');
+                if (config['view_after_generate']) {
+                    vscode.commands.executeCommand('extension.doxygen-runner.view_doxygen', this.basedir);
+                }
             });
         }));
     }


### PR DESCRIPTION
I like the extension, but I'm not interested in viewing the html within vscode. I added a configuration option to disable automatically viewing the documentation after generating.